### PR TITLE
Ensure we are operating in app root folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
+process.chdir(__dirname);
 require("./lib/server")();


### PR DESCRIPTION
The relative paths used in app break when process is not started from app directory - for example, when launched by upstart script.
