### PR TITLE
Store config as json instead of js.

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,0 @@
-module.exports = {
-	port: 9000,
-	public: true
-};

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+    // webserver port
+	"port": 9000,
+    "public": true
+}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,29 @@
-process.chdir(__dirname);
-var shout = require("./lib/server");
-shout();
+/* jshint node:true, camelcase: true */
+"use strict";
+
+/**
+ * Module dependencies
+ */
+// 3rd-party
+var Promise = require("bluebird");
+var stripJsonComments = require("strip-json-comments");
+
+// node.js
+var fs = Promise.promisifyAll(require("fs"));
+
+// retrieve, clean, and load config.json
+// TODO: expose path setting for config.json
+fs.readFileAsync("./config.json", "utf8")
+    .then(stripJsonComments)
+    .then(JSON.parse)
+    .then(function(config) {
+
+        var shout = require("./lib/server");
+        shout(config);
+    })
+    .catch(function(e) {
+        console.log(e);
+    });
+
+
+

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,15 @@
+/**
+ * Module dependencies
+ */
+
+// 3rd-party
 var _ = require("lodash");
-var Client = require("./client");
-var config = require("../config") || {};
 var http = require("connect");
 var io = require("socket.io");
+
+// app
+var Client = require("./client");
+
 
 var sockets = null;
 var clients = [];
@@ -24,18 +31,28 @@ var inputs = [
 	"whois"
 ];
 
-module.exports = function() {
-	sockets = io(http().use(http.static("client")).listen(config.port || 9000));
+module.exports = server.bind(server);
+
+function server(config) {
+
+	this.config = config;
+
+	sockets = io(http().use(http.static("client")).listen(this.config.port || 9000));
+
 	sockets.on("connect", function(socket) {
-		if (config.public) {
-			auth.call(socket);
+
+		this.socket = socket;
+
+		if (this.config.public) {
+			this.auth();
 		} else {
-			init(socket);
+			this.init(socket);
 		}
-	});
+	}.bind(this));
 };
 
-function init(socket, client) {
+server.init = function(socket, client) {
+
 	if (!client) {
 		socket.emit("auth");
 		socket.on("auth", auth);
@@ -43,8 +60,8 @@ function init(socket, client) {
 		socket.on(
 			"input",
 			function(data) {
-				input(client, data);
-			}
+				this.input(client, data);
+			}.bind(this)
 		);
 		socket.on(
 			"conn",
@@ -57,36 +74,37 @@ function init(socket, client) {
 			networks: client.networks
 		});
 	}
-}
+};
 
-function auth(data) {
-	var socket = this;
-	if (config.public) {
+server.auth = function(data) {
+
+	if (this.config.public) {
 		var client = new Client(sockets);
 		clients.push(client);
-		socket.on("disconnect", function() {
+
+		this.socket.on("disconnect", function() {
 			clients = _.without(clients, client);
 			client.quit();
 		});
-		init(socket, client);
+		this.init(this.socket, client);
 	} else {
 		if (false) {
 			// ..
 		}
 	}
-}
+};
 
-function input(client, data) {
+server.input = function(client, data) {
 	var target = client.find(data.target);
 
 	var text = data.text;
 	if (text.charAt(0) !== "/") {
 		text = "/say " + text;
 	}
-	
+
 	var args = text.split(" ");
 	var cmd = args.shift().replace("/", "").toLowerCase();
-	
+
 	inputs.forEach(function(plugin) {
 		try {
 			var fn = require("./plugins/inputs/" + plugin);
@@ -100,4 +118,4 @@ function input(client, data) {
 			// ..
 		}
 	});
-}
+};

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "server"
   ],
   "main": "http://localhost:9000/",
-	"node-main": "./index.js",
-	"single-instance": false,
-	"window": {
-		"title": "Shout",
-		"toolbar": false,
-		"height": 640,
-		"width": 1024
-	},
+  "node-main": "./index.js",
+  "single-instance": false,
+  "window": {
+    "title": "Shout",
+    "toolbar": false,
+    "height": 640,
+    "width": 1024
+  },
   "scripts": {
     "start": "node index.js"
   },
@@ -32,11 +32,13 @@
     "url": "https://github.com/erming/shout.git"
   },
   "dependencies": {
+    "bluebird": "^2.2.2",
     "connect": "~2.19.6",
     "lodash": "~2.4.1",
     "moment": "~2.7.0",
     "slate-irc": "~0.6.0",
-    "socket.io": "~1.0.6"
+    "socket.io": "~1.0.6",
+    "strip-json-comments": "^0.1.3"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
- As a bonus, comments can be placed within `config.json`. They're stripped via https://github.com/sindresorhus/strip-json-comments before parsed as a JSON object.
- I put in the bluebird promise library to organize flow.
- Refactored `server.js` a little to organize things.
