### PR TITLE
Customizable server name

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -74,7 +74,8 @@ Client.prototype.connect = function(args) {
 	var client = this;
 	var server = {
 		host: args.host || "irc.freenode.org",
-		port: args.port || 6667
+		port: args.port || 6667,
+		name: args.name
 	};
 
 	var stream = args.tls ? tls.connect(server) : net.connect(server);
@@ -92,6 +93,7 @@ Client.prototype.connect = function(args) {
 
 	var network = new Network({
 		host: server.host,
+		name: server.name,
 		irc: irc
 	});
 

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -11,9 +11,9 @@ function Network(attr) {
 		connected: false,
 		host: "",
 		id: id++,
-		irc: null,
-		name: prettify(attr.host)
+		irc: null
 	}, attr));
+  this.name = attr.name || prettify(attr.host);
 	this.channels.unshift(
 		new Chan({name: this.name, type: Chan.Type.LOBBY})
 	);


### PR DESCRIPTION
Read server name from config if "name" is present.

I'm connecting shout to my znc in local network with IP address (192.168.x.x) and client shows the name of the server "168".
That's not pretty so I added "name" to my user.json and let shout display it.
