### PR TITLE
Add server password. Add rejectUnauthorized to disable SSL verification

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -72,10 +72,11 @@ Client.prototype.find = function(id) {
 
 Client.prototype.connect = function(args) {
 	var client = this;
-	var server = {
-		host: args.host || "irc.freenode.org",
-		port: args.port || 6667
-	};
+	var server = _.defaults(_.pick(args, ['host', 'port', 'rejectUnauthorized']), {
+		host: "irc.freenode.org",
+		port: 6667,
+		rejectUnauthorized: true
+	});
 
 	var stream = args.tls ? tls.connect(server) : net.connect(server);
 	stream.on("error", function(e) {
@@ -86,6 +87,11 @@ Client.prototype.connect = function(args) {
 	var realname = args.realname || "Shout User";
 
 	var irc = slate(stream);
+
+	if (args.password) {
+		irc.pass(args.password);
+	}
+
 	irc.me = nick;
 	irc.nick(nick);
 	irc.user(nick, realname);


### PR DESCRIPTION
Support for two new `network` configuratiion options

`network.password`: the server password (optional)
`network.rejectUnauthorized`: false to ignore SSL verification errors (optional, default: true)

```
{
  "user": "username",
  "password": "password",
  "networks": [{
    "host": "irc.freenode.org",
    "port": 6667,
    "tls": true,
    "nick": "nickname",
    "realname": "Fullname",
    "rejectUnauthorized": false,
    "join": "#foobar",
    "password": "serverpassword"
  }]
}
```
