### PR TITLE
Load Google font with protocol relative URL

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1,6 +1,4 @@
-@import url(
-	http://fonts.googleapis.com/css?family=Lato:400,700
-);
+@import url('//fonts.googleapis.com/css?family=Lato:400,700');
 @font-face {
 	font-family: "FontAwesome";
 	src: url("fonts/fontawesome.svg") format("svg"), url("fonts/fontawesome.woff") format("woff");


### PR DESCRIPTION
This allows for HTTPS serving of Shout.

With the specified 'http' protocol you would get the following error when loaded over HTTPS: 

```
[blocked] The page at 'URL-HERE' was loaded over HTTPS, but ran insecure content from 'http://fonts.googleapis.com/css?family=Lato:400,700': this content should also be loaded over HTTPS.
```

See this post by @paulirish about [the protocol relative url](http://www.paulirish.com/2010/the-protocol-relative-url/).
