### PR TITLE
Lowercase user search string in chat sidebar to match lowercased names

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -341,7 +341,7 @@ $(function() {
 	});
 
 	chat.on("input", ".search", function() {
-		var value = $(this).val();
+		var value = $(this).val().toLowerCase();
 		var names = $(this).closest(".users").find(".names");
 		names.find("button").each(function() {
 			var btn = $(this);


### PR DESCRIPTION
Makes it possible to find users like `ChanServ` by writing `C`, instead of only `c` - disregarding the casing.

Before it could only find users if you searched with lowercase, since all values are lowercased when the check is done.
