### PR TITLE
Remove login form from DOM after a successful login.

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -309,7 +309,12 @@ $(function() {
 
 		viewport.removeClass();
 
-		$("#windows .active").removeClass("active");
+		var active = $("#windows .active").removeClass("active");
+
+		if (active.attr('id') == 'sign-in') {
+			active.detach();
+		}
+
 		var chan = $(target)
 			.addClass("active")
 			.trigger("show")


### PR DESCRIPTION
This fixes issues when using password manager browser extensions.
