### PR TITLE
Don't echo password on commandline when reading

### DIFF
--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -41,7 +41,8 @@ program
 			return;
 		}
 		require("read")({
-			prompt: "Password: "
+			prompt: "Password: ",
+			silent: true
 		}, function(err, password) {
 			console.log("");
 			if (err) {


### PR DESCRIPTION
Currently, typing in your password when creating a new account
echos it on to the commandline, which is bad.
