### PR TITLE
Specify full stack of fonts for the chat input as well

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -404,7 +404,7 @@ button {
 }
 #chat,
 #windows .header {
-	font: 13px Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+	font: 13px Consolas, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
 }
 #chat button:hover {
 	opacity: .6;
@@ -670,7 +670,7 @@ button {
 }
 #form input {
 	border: 1px solid #cfdae1;
-	font: 13px Consolas, monospace;
+	font: 13px Consolas, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
 	border-radius: 2px;
 	height: 100%;
 	outline: none;


### PR DESCRIPTION
Also removes Menlo from the stack, since it is not fixed-width
unlike the others in the stack, and Monaco already accounts
for OS X
