### PR TITLE
Added custom quit message functionality. Resolves erming/shout#71

### DIFF
--- a/src/plugins/inputs/quit.js
+++ b/src/plugins/inputs/quit.js
@@ -7,11 +7,12 @@ module.exports = function(network, chan, cmd, args) {
 	
 	var client = this;
 	var irc = network.irc;
+	var quitMessage = args[0] ? args.join(" ") : "";
 	
 	client.networks = _.without(client.networks, network);
 	client.emit("quit", {
 		network: network.id
 	});
 	
-	irc.quit();
+	irc.quit(quitMessage);
 };


### PR DESCRIPTION
Note: Freenode requires the client to be connected for at least 5 minutes before it will show the custom quit message (to prevent spam).
