### PR TITLE
Add username field to user info.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -138,6 +138,7 @@ Client.prototype.connect = function(args) {
 	});
 
 	var nick = args.nick || "shout-user";
+	var username = args.username || nick;
 	var realname = args.realname || "Shout User";
 
 	var irc = slate(stream);
@@ -148,7 +149,7 @@ Client.prototype.connect = function(args) {
 
 	irc.me = nick;
 	irc.nick(nick);
-	irc.user(nick, realname);
+	irc.user(username, realname);
 
 	var network = new Network({
 		host: server.host,

--- a/users/example/user.json
+++ b/users/example/user.json
@@ -9,6 +9,7 @@
 		"tls": true,
 		"password": "serverpw",
 		"nick": "john",
+		"username": "john",
 		"realname": "John Doe",
 		"commands": [
 			"/msg NickServ identify password",


### PR DESCRIPTION
Most of the networks don't allow unicode username. This patch allows users to specify username optionally. When specified, username is used for connecting IRC networks instead of nickname.
