### PR TITLE
fix command-line scripts to work with username.json files

### DIFF
--- a/src/command-line/edit.js
+++ b/src/command-line/edit.js
@@ -5,7 +5,7 @@ var Helper = require("../helper");
 
 program
 	.command("edit <name>")
-	.description("Edit user: '" + Helper.HOME + "/users/<name>/user.json'")
+	.description("Edit user: '" + Helper.HOME + "/users/<name>.json'")
 	.action(function(name) {
 		var users = new ClientManager().getUsers();
 		if (users.indexOf(name) === -1) {
@@ -16,7 +16,7 @@ program
 		}
 		child.spawn(
 			process.env.EDITOR || "vi",
-			[require("path").join(Helper.HOME, "users", name, "user.json")],
+			[require("path").join(Helper.HOME, "users", name + ".json")],
 			{stdio: "inherit"}
 		);
 	});

--- a/src/command-line/reset.js
+++ b/src/command-line/reset.js
@@ -15,7 +15,7 @@ program
 			console.log("");
 			return;
 		}
-		var file = Helper.HOME + "/users/" + name + "/user.json";
+		var file = Helper.HOME + "/users/" + name + ".json";
 		var user = require(file);
 		require("read")({
 			prompt: "Password: ",


### PR DESCRIPTION
`index.js edit` and `index.js reset` were still looking for the older `HOME/user/USERNAME/user.json` format. I've just changed it to point to the new `HOME/user/USERNAME.json` format.

This goes with issue #260 
