### PR TITLE
Support terminator in style parser

### DIFF
--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -50,42 +50,42 @@ function uri(text) {
 
 var regex = {
 	color: /\003([0-9]{1,2})[,]?([0-9]{1,2})?([^\003]+)/,
-    terminator: /\x0D/,
+	terminator: /\x0D/,
 	styles: [
-        [/\002([^\002]+)(\002)?/, ["<b>", "</b>"]],
-        [/\037([^\037]+)(\037)?/, ["<u>", "</u>"]],
-    ]
+		[/\002([^\002]+)(\002)?/, ["<b>", "</b>"]],
+		[/\037([^\037]+)(\037)?/, ["<u>", "</u>"]],
+	]
 };
 function colors(text) {
 	if (!text) {
 		return text;
 	}
-    if (regex.terminator.test(text)) {
-        return $.map(text.split(regex.terminator), colors);
-    }
-    if (regex.color.test(text)) {
-    	var match;
-        while (match = regex.color.exec(text)) {
-            var color = "color-" + match[1];
-            var bg = match[2];
-            if (bg) {
-           		color += " bg-" + bg;
-           	}
-            var text = text.replace(
-            	match[0],
-            	"<span class='" + color + "'>" + match[3] + "</span>"
-            );
-        }
-    }
-    for (var i in regex.styles) {
-        var pattern = regex.styles[i][0];
-        var style = regex.styles[i][1];
-        if (pattern.test(text)) {
-        	var match;
-            while (match = pattern.exec(text)) {
-                text = text.replace(match[0], style[0] + match[1] + style[1]);
-            }
-        }
-    }
-    return text;
+	if (regex.terminator.test(text)) {
+		return $.map(text.split(regex.terminator), colors);
+	}
+	if (regex.color.test(text)) {
+		var match;
+		while (match = regex.color.exec(text)) {
+			var color = "color-" + match[1];
+			var bg = match[2];
+			if (bg) {
+				color += " bg-" + bg;
+			}
+			var text = text.replace(
+				match[0],
+				"<span class='" + color + "'>" + match[3] + "</span>"
+			);
+		}
+	}
+	for (var i in regex.styles) {
+		var pattern = regex.styles[i][0];
+		var style = regex.styles[i][1];
+		if (pattern.test(text)) {
+			var match;
+			while (match = pattern.exec(text)) {
+				text = text.replace(match[0], style[0] + match[1] + style[1]);
+			}
+		}
+	}
+	return text;
 }


### PR DESCRIPTION
Kind of still wish we would collaborate [on my parser](https://github.com/megawac/irc-style-parser) and figure a way to rid the underscore dependency :/

Ah well. I also reindented the colour parser as the rest of the file seems to be using tabs

Todo: support nested colours (#264)
