### PR TITLE
Support nested colours

### DIFF
--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -60,10 +60,12 @@ function colors(text) {
 		return text;
 	}
     if (regex.color.test(text)) {
-    	var match;
+    	var match, bg;
         while (match = regex.color.exec(text)) {
             var color = "color-" + match[1];
-            var bg = match[2];
+            if (match[2]) {
+            	bg = match[2];
+            }
             if (bg) {
            		color += " bg-" + bg;
            	}


### PR DESCRIPTION
This is pretty naive support, but should work for most cases (e.g. case I mentioned a couple weeks ago https://github.com/erming/shout/commit/d86005e84ab671871308c496791fed8de38878a7)

``` js
colours("\x031,2back\x031wheres my back2")
// => "<span class='color-1 bg-2'>back</span><span class='color-1 bg-2'>wheres my back2</span>"
```
