### PR TITLE
Add socket.io transports to configuration

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -52,7 +52,7 @@ module.exports = {
 	// @default  true
 	//
 	autoload: true,
-	
+
 	//
 	// Prefetch URLs
 	//
@@ -162,6 +162,13 @@ module.exports = {
 		//
 		join: "#foo, #shout-irc"
 	},
+	//
+	// Set socket.io transports
+	//
+	// @type     array
+	// @default  ['polling', 'websocket']
+	//
+	transports: ['polling', 'websocket']
 
 	//
 	// Run Shout with HTTPS support.

--- a/src/server.js
+++ b/src/server.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
 	var app = express()
 		.use(index)
 		.use(express.static("client"));
-	
+
 	app.enable("trust proxy");
 
 	var server = null;
@@ -26,6 +26,7 @@ module.exports = function(options) {
 	var protocol = https.enable ? "https" : "http";
 	var port = config.port;
 	var host = config.host;
+	var transports = config.transports || ['websocket', 'polling'];
 
 	if (!https.enable){
 		server = require("http");
@@ -42,7 +43,10 @@ module.exports = function(options) {
 		require("./identd").start(config.identd.port);
 	}
 
-	sockets = io(server);
+	sockets = io(server, {
+		transports: transports
+	});
+
 	sockets.on("connect", function(socket) {
 		if (config.public) {
 			auth.call(socket);


### PR DESCRIPTION
I wan't to install shout, but I can't since it's not possible for me to proxy websocket-traffic through Apache.
Therefore I added a new configurable option for defining which transports socket.io is allowed to use and managed to get everything up and running.
