### PR TITLE
Add basic environment for unit testing with mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "url": "https://github.com/erming/shout.git"
   },
   "scripts": {
-    "start": "node index"
+    "start": "node index",
+    "test": "NODE_ENV=test mocha test/**/*.js"
   },
   "keywords": [
     "browser",
@@ -40,6 +41,7 @@
     "grunt": "~0.4.5",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-watch": "^0.6.1",
-    "handlebars": "^2.0.0"
+    "handlebars": "^2.0.0",
+    "mocha": "~2.0.1"
   }
 }

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -1,0 +1,37 @@
+var assert = require('assert');
+
+var util = require('../util');
+var link = require('../../src/plugins/irc-events/link.js');
+
+describe('Link plugin', function() {
+  before(function(done) {
+    this.app = util.createWebserver();
+    this.connection = this.app.listen(9002, done);
+  });
+
+  after(function(done) {
+    this.connection.close(done);
+  });
+
+  beforeEach(function() {
+    this.irc = util.createClient();
+    this.network = util.createNetwork();
+  });
+
+  it('should be able to fetch basic information about URLs', function(done) {
+    var plugin = link.call(this.irc, this.irc, this.network);
+
+    this.app.get('/basic', function(req, res) {
+      res.send('<title>test</title>');
+    });
+
+    this.irc.createMessage({
+      message: 'http://localhost:9002/basic'
+    });
+
+    this.irc.once('toggle', function(data) {
+      assert.equal(data.head, 'test');
+      done();
+    })
+  });
+});

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,43 @@
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var _ = require('lodash');
+var express = require('express');
+
+function MockClient(opts) {
+  this.me = 'test-user';
+
+  for(k in opts) {
+    this[k] = opts[k];
+  }
+}
+util.inherits(MockClient, EventEmitter);
+
+MockClient.prototype.createMessage = function(opts) {
+
+  var message = _.extend({
+    message: 'dummy message',
+    from: 'test-user',
+    to: 'test-channel'
+  }, opts);
+
+  this.emit('message', message);
+}
+
+module.exports = {
+  createClient: function() {
+    return new MockClient();
+  },
+  createNetwork: function() {
+    return {
+      channels: [{
+        name: 'test-channel',
+        messages: []
+      }]
+    }
+  },
+  createWebserver: function() {
+    return express();
+  }
+}
+
+


### PR DESCRIPTION
Includes one test for link plugin and `util.js` file containing some helper methods for creating dummy irc-client/network/webserver

Tests can be run with `npm test`
