### PR TITLE
Switch from superagent to request

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "read": "^1.0.5",
     "slate-irc": "~0.7.3",
     "socket.io": "~1.0.6",
-    "superagent": "^0.18.2"
+    "request": "~2.51.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Superagent throws an `unknown compression method` with some urls and it's currently impossible to catch those errors which leads to Shout crashing.  

`plugins/irc-events/link.js`is currently the only plugin that uses any library for creating HTTP-requests so I'd say that at this point it would be easier just to change the HTTP-client we're using. 
https://github.com/visionmedia/superagent/issues/410

Steps to reproduce:
1. Paste this url to any channel: http://www.expert.fi/Tuotteet/Tietokoneet/Naytot/Samsung-U28D590D
