### PR TITLE
add capability to run at non-root path

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,9 +15,9 @@
 	<link rel="stylesheet" href="css/style.css">
 	<link id="theme" rel="stylesheet" href="<%= theme %>">
 
-	<link rel="shortcut icon" href="/img/favicon.png">
-	<link rel="icon" sizes="192x192" href="/img/touch-icon-192x192.png">
-	<link rel="apple-touch-icon" sizes="120x120" href="/img/apple-touch-icon-120x120.png">
+	<link rel="shortcut icon" href="img/favicon.png">
+	<link rel="icon" sizes="192x192" href="img/touch-icon-192x192.png">
+	<link rel="apple-touch-icon" sizes="120x120" href="img/apple-touch-icon-120x120.png">
 
 	</head>
 	<body class="<%= public ? "public" : "" %>">

--- a/client/index.html
+++ b/client/index.html
@@ -11,14 +11,13 @@
 
 	<title>Shout</title>
 
-	<link rel="stylesheet" href="css/bootstrap.css">
-	<link rel="stylesheet" href="css/style.css">
+	<link rel="stylesheet" href="<%= rootpath %>css/bootstrap.css">
+	<link rel="stylesheet" href="<%= rootpath %>css/style.css">
 	<link id="theme" rel="stylesheet" href="<%= theme %>">
 
-	<link rel="shortcut icon" href="img/favicon.png">
-	<link rel="icon" sizes="192x192" href="img/touch-icon-192x192.png">
-	<link rel="apple-touch-icon" sizes="120x120" href="img/apple-touch-icon-120x120.png">
-
+	<link rel="shortcut icon" href="<%= rootpath %>img/favicon.png">
+	<link rel="icon" sizes="192x192" href="<%= rootpath %>img/touch-icon-192x192.png">
+	<link rel="apple-touch-icon" sizes="120x120" href="<%= rootpath %>img/apple-touch-icon-120x120.png">
 	</head>
 	<body class="<%= public ? "public" : "" %>">
 
@@ -283,9 +282,9 @@
 	</div>
 	</div>
 
-	<script src="js/libs.min.js"></script>
-	<script src="js/shout.templates.js"></script>
-	<script src="js/shout.js"></script>
+	<script src="<%= rootpath %>js/libs.min.js"></script>
+	<script src="<%= rootpath %>js/shout.templates.js"></script>
+	<script src="<%= rootpath %>js/shout.js"></script>
 
 	</body>
 </html>

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -37,7 +37,7 @@ $(function() {
 
 	try {
 		var pop = new Audio();
-		pop.src = "audio/pop.ogg";
+	        pop.src = config.rootpath + "audio/pop.ogg";
 	} catch(e) {
 		var pop = {
 			play: $.noop

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -37,7 +37,7 @@ $(function() {
 
 	try {
 		var pop = new Audio();
-		pop.src = "/audio/pop.ogg";
+		pop.src = "audio/pop.ogg";
 	} catch(e) {
 		var pop = {
 			play: $.noop

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -64,6 +64,18 @@ module.exports = {
 	//
 	prefetch: true,
 
+        //
+        // Serving path
+        //
+        // The path at which shout is available.
+        // For example if you set this to /chat,
+        // shout will be available at http://0.0.0.0:9000/chat
+        //
+        // @type     string
+        // @default  "/"
+        //
+        rootpath: "/",
+
 	//
 	// Log settings
 	//

--- a/src/server.js
+++ b/src/server.js
@@ -46,7 +46,7 @@ module.exports = function(options) {
 	sockets = io(server, {
 		transports: transports
 	});
-        sockets.path(config.rootpath + '/socket.io');
+        sockets.path(config.rootpath + 'socket.io');
 
 	sockets.on("connect", function(socket) {
 		if (config.public) {

--- a/src/server.js
+++ b/src/server.js
@@ -16,8 +16,8 @@ module.exports = function(options) {
 	config = _.extend(config, options);
 
 	var app = express()
-		.use(index)
-		.use(express.static("client"));
+	        .use(config.rootpath, index)
+	        .use(config.rootpath, express.static("client"));
 
 	app.enable("trust proxy");
 
@@ -36,7 +36,7 @@ module.exports = function(options) {
 		server = server.createServer({
 			key: fs.readFileSync(https.key),
 			cert: fs.readFileSync(https.certificate)
-		}, app).listen(port, host)
+		}, app).listen(port, host);
 	}
 
 	if ((config.identd || {}).enable) {
@@ -46,6 +46,7 @@ module.exports = function(options) {
 	sockets = io(server, {
 		transports: transports
 	});
+        sockets.path(config.rootpath + '/socket.io');
 
 	sockets.on("connect", function(socket) {
 		if (config.public) {


### PR DESCRIPTION
Hello,

With this PR, setting the new config setting `rootpath` to `/chat` will serve shout at `http://0.0.0.0:9000/chat` (if all other defaults are left untouched).

I tested it with a fresh install and it works just like before, and by setting the new variable and it works as well. 
By "works", I mean the main page shows up without issues, and chatting/reading remain as functional.

this fixes #333 #243 

Have a nice evening!

Louis "Baboon" Kottmann