### PR TITLE
support for away messages

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -15,6 +15,7 @@ module.exports = Client;
 
 var id = 0;
 var events = [
+	"away",
 	"ctcp",
 	"error",
 	"join",

--- a/src/plugins/irc-events/away.js
+++ b/src/plugins/irc-events/away.js
@@ -1,0 +1,24 @@
+var _ = require("lodash");
+var Chan = require("../../models/chan");
+var Msg = require("../../models/msg");
+
+module.exports = function(irc, network) {
+	var client = this;
+	irc.on("away", function(data) {
+		var chan = _.findWhere(network.channels, {name: data.nick});
+		if (typeof chan === "undefined") {
+			return;
+		}
+
+		var msg = new Msg({
+			type: Msg.Type.WHOIS,
+			from: data.nick,
+			text: "is away: " + data.message
+		});
+		chan.messages.push(msg);
+		client.emit("msg", {
+			chan: chan.id,
+			msg: msg
+		});
+	});
+};

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -24,7 +24,8 @@ module.exports = function(irc, network) {
 			hostname: "from",
 			realname: "is",
 			channels: "on",
-			server: "using"
+			server: "using",
+			away: "is away:"
 		};
 		var i = 0;
 		for (var k in data) {


### PR DESCRIPTION
This is a rough implementation, and it relies on https://github.com/slate/slate-irc/pull/27 being pulled.

Here's the state of affairs:

An away message can be received as part of a whois reply. It can also be received on its own, if talking to someone who is away. Slate-irc sends it as part of the `whois` event in the former case, and as an `away` event in both cases.

At first I ignored the away message from the `whois` event, and opened a new channel if it didn't already exist when an `away` event is received. This introduces a race condition when doing a whois on a user without an existing channel, as both `whois` and `away` try to open the new channel at the same time.

My makeshift solution was to ignore `away` events from users without a channel, and show away messages from `whois` events. It avoids the race condition but it causes duplicate away messages when doing a whois on an user who has a channel.

I would suggest using a mutex lock on the channel list, but I am not familiar enough with shout's codebase or with node to do it myself. I can do it if someone points me in the right direction though :)
