### PR TITLE
use users icon for user list instead of second menu icon

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -122,6 +122,9 @@ button {
 	font: 14px FontAwesome;
 	content: "\f0c9";
 }
+#viewport .rt:before {
+	content: "\f0c0";
+}
 #viewport .rt {
 	display: block;
 	float: right;


### PR DESCRIPTION
Before, on mobile there were 2 menu icons, one on the left and one on the right. This makes it clearer what’s behind the right icon.

The icon doesn’t look particularly awesome but that’s Fontawesome …

Please review @erming 