### PR TITLE
Enable logging in public mode and load messages on connect

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -179,6 +179,15 @@ $(function() {
 		}
 		whois = false;
 		chan.click();
+
+		if (data.messages) {
+			var messages = chan.find(".messages");
+			messages.scrollTop(messages.scrollHeight());
+
+			if (data.chan.messages.length == 100) {
+				chan.find(".show-more").addClass("show");
+			}
+		}
 	});
 
 	socket.on("msg", function(data) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "read": "^1.0.5",
     "request": "^2.51.0",
     "slate-irc": "~0.7.3",
-    "socket.io": "~1.0.6"
+    "socket.io": "~1.0.6",
+    "ttl": "~1.3.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/src/client.js
+++ b/src/client.js
@@ -79,21 +79,19 @@ Client.prototype.emit = function(event, data) {
 		this.sockets.in(this.id).emit(event, data);
 	}
 	var config = this.config || {};
-	if (config.log === true) {
-		if (event == "msg") {
-			var target = this.find(data.chan);
-			if (target) {
-				var chan = target.chan.name;
-				if (target.chan.type == Chan.Type.LOBBY) {
-					chan = target.network.host;
-				}
-				log.write(
-					this.name,
-					target.network.host,
-					chan,
-					data.msg
-				);
+	if (event == "msg") {
+		var target = this.find(data.chan);
+		if (target) {
+			var chan = target.chan.name;
+			if (target.chan.type == Chan.Type.LOBBY) {
+				chan = target.network.host;
 			}
+			log.write(
+				this.name,
+				target.network.host,
+				chan,
+				data.msg
+			);
 		}
 	}
 };

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -2,6 +2,7 @@ var _ = require("lodash");
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
 var User = require("../../models/user");
+var log = require("../../log");
 
 module.exports = function(irc, network) {
 	var client = this;
@@ -13,9 +14,16 @@ module.exports = function(irc, network) {
 			});
 			network.channels.push(chan);
 			client.save();
-			client.emit("join", {
-				network: network.id,
-				chan: chan
+
+			log.load(irc.me, client.name, network.host, data.channel, function(messages) {
+				if (typeof messages !== "undefined") {
+					chan.messages = messages.concat(chan.messages);
+				}
+
+				client.emit("join", {
+					network: network.id,
+					chan: chan
+				});
 			});
 		}
 		var users = chan.users;


### PR DESCRIPTION
Always log messages, even in public mode, as in #295.  Messages will only be logged as long as at least one public client is connected to a channel.  When all clients disconnect, messages aren't logged anymore.

Also, load messages from the log file when joining a channel. 
