### PR TITLE
Handle TLS connection errors when 'bind' is set

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -138,7 +138,7 @@ Client.prototype.connect = function(args) {
 			socket.on("error", function(e) {
 				var msg = new Msg({
 					type: Msg.Type.ERROR,
-					text: "Can't connect, is server address correct?"
+					text: "Connection error. Check the server settings."
 				});
 				client.emit("msg", {
 					msg: msg
@@ -156,7 +156,7 @@ Client.prototype.connect = function(args) {
 		stream.end();
 		var msg = new Msg({
 			type: Msg.Type.ERROR,
-			text: "Connection error."
+			text: "Connection error. Check the server settings."
 		});
 		client.emit("msg", {
 			msg: msg

--- a/src/client.js
+++ b/src/client.js
@@ -133,6 +133,18 @@ Client.prototype.connect = function(args) {
 		server.localAddress = config.bind;
 		if(args.tls) {
 			var socket = net.connect(server);
+
+			// Usually problems with server/connection settings
+			socket.on("error", function(e) {
+				var msg = new Msg({
+					type: Msg.Type.ERROR,
+					text: "Can't connect, is server address correct?"
+				});
+				client.emit("msg", {
+					msg: msg
+				});
+                        });
+
 			server.socket = socket;
 		}
 	}

--- a/src/client.js
+++ b/src/client.js
@@ -139,6 +139,7 @@ Client.prototype.connect = function(args) {
 	socket.on("error", function(e) {
 		console.log("Client#connect():\n" + e);
 		socket.end();
+
 		var msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: "Connection error. Check the server settings."
@@ -150,9 +151,24 @@ Client.prototype.connect = function(args) {
 
 	// Connection is already complete if not using TLS
 	var stream = socket;
+
 	if(args.tls) {
 		server.socket = socket;
 		stream = tls.connect(server);
+
+		// Problems with TLS, e.g. wrong version number
+		stream.on("error", function(e) {
+			console.log("Client#TLS-connect():\n" + e);
+			socket.end();
+
+			var msg = new Msg({
+				type: Msg.Type.ERROR,
+				text: "Connection error. TLS negotiation failed."
+			});
+			client.emit("msg", {
+				msg: msg
+			});
+		});
 	}
 
 	var nick = args.nick || "shout-user";


### PR DESCRIPTION
There is no error handling when config.bind is set and the connection uses TLS and so the server crashes to an unhandled error if an error occurs.
Also, refactored the code a bit so there won't be multiple places were the first net.connect() can happen. It also helps to separate tls.connect() so that those errors can be handled separately from net.connect().
