### PR TITLE
User-specific bind address setting

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -67,6 +67,8 @@ function Client(sockets, name, config) {
 		var delay = 0;
 		(config.networks || []).forEach(function(n) {
 			setTimeout(function() {
+				// User-specific bind (localAddress) for networks
+				n.bind = config.bind;
 				client.connect(n);
 			}, delay);
 			delay += 1000;
@@ -126,15 +128,16 @@ Client.prototype.connect = function(args) {
 		name: args.name || "",
 		host: args.host || "irc.freenode.org",
 		port: args.port || (args.tls ? 6697 : 6667),
+		localAddress: args.bind || config.bind || undefined,
 		rejectUnauthorized: false
 	};
+	
+	// XXX: "family" requires nodejs 0.12, but setting it won't hurt
+	server.family = net.isIP(server.localAddress) || undefined;
 
-	if (config.bind) {
-		server.localAddress = config.bind;
-		if(args.tls) {
-			var socket = net.connect(server);
-			server.socket = socket;
-		}
+	if (server.localAddress && args.tls) {
+		var socket = net.connect(server);
+		server.socket = socket;
 	}
 
 	var stream = args.tls ? tls.connect(server) : net.connect(server);

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -80,6 +80,7 @@ ClientManager.prototype.addUser = function(name, password) {
 			user: name,
 			password: password || "",
 			log: false,
+			bind: "",
 			networks: []
 		};
 		mkdirp.sync(path);


### PR DESCRIPTION
Because many IRC servers allow only a few connections from the same IP address, it becomes necessary to use multiple IP addresses for IRC connections. So I added a setting for binding users' connections to different addresses.

Btw, without setting server.family I couldn't get binding to IPv6 addresses to work.
I haven't tested if setting server.family in nodejs 0.10 causes problems (or if anyone cares about 0.10?) but I think it shouldn't. I can test it if no one confirms.
