### PR TITLE
Add option to automatically connect to network on client visit

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -258,6 +258,16 @@
 								</div>
 							</div>
 							<div class="col-sm-12">
+								<h2>Networks</h2>
+							</div>
+							<div class="col-sm-12">
+								<label class="opt">
+									<input type="checkbox" name="autojoin">
+									Auto connect to default network
+								</label>
+							</div>
+
+							<div class="col-sm-12">
 								<h2>About Shout</h2>
 							</div>
 							<div class="col-sm-12">

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -338,6 +338,7 @@ $(function() {
 		part: true,
 		thumbnails: true,
 		quit: true,
+		autojoin: false,
 	}, $.cookie("settings"));
 
 	for (var i in options) {
@@ -665,14 +666,22 @@ $(function() {
 
 	forms.on("submit", "form", function(e) {
 		e.preventDefault();
-		var event = "auth";
 		var form = $(this);
 		form.find(".btn")
 			.attr("disabled", true)
 			.end();
 		if (form.closest(".window").attr("id") == "connect") {
-			event = "conn";
+			submitForm(form, 'conn');
+		} else {
+			submitForm(form, 'auth');
 		}
+	});
+
+	if (options.autojoin) {
+		submitForm($('#connect form'), 'conn');
+	}
+
+	function submitForm(form, event) {
 		var values = {};
 		$.each(form.serializeArray(), function(i, obj) {
 			if (obj.value !== "") {
@@ -690,7 +699,7 @@ $(function() {
 		socket.emit(
 			event, values
 		);
-	});
+	}
 
 	forms.on("input", ".nick", function() {
 		var nick = $(this).val();


### PR DESCRIPTION
Adds an option to the client settings to automatically initiate a connection to the network specified in the client settings as soon as the client page is loaded.

I want to use it to create a kiosk mode (for a read-only view of IRC), but others may want to use it for when they always connect to the same network using the same nickname, and don't want to have to click "Connect" manually each time they open Shout's web client interface.