### PR TITLE
client/js/shout.js: no longer closes Notifications in Safari

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -35,6 +35,13 @@ $(function() {
 		$("html").addClass("web-app-mode");
 	}
 
+	// Browser detection, http://stackoverflow.com/a/2401861.
+	var isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0; // Opera 8.0+ (UA detection to detect Blink/v8-powered Opera)
+	var isFirefox = typeof InstallTrigger !== 'undefined'; // Firefox 1.0+
+	var isSafari = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0; // At least Safari 3+: "[object HTMLElementConstructor]"
+	var isChrome = !!window.chrome && !isOpera; // Chrome 1+
+	var isIE = /*@cc_on!@*/false || !!document.documentMode; // At least IE6
+
 	try {
 		var pop = new Audio();
 		pop.src = "/audio/pop.ogg";
@@ -582,9 +589,12 @@ $(function() {
 						button.click();
 						this.close();
 					};
-					window.setTimeout(function() {
-						notify.close();
-					}, 5 * 1000);
+
+					if (!isSafari) {
+						window.setTimeout(function() {
+							notify.close();
+						}, 5 * 1000);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Safari uses the native notification API in OS X (and iOS?), which means it'll take care of dismissing notifications. The .gif doesn't show automatic dismissing, but it's about 3-5 seconds.

<img src="https://cloud.githubusercontent.com/assets/6705160/7464289/0d44eff0-f2c2-11e4-9a7d-dd007804244f.gif">