### PR TITLE
Prevent browsers leaking referrer headers

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 	<meta name="mobile-web-app-capable" content="yes">
+	<meta name="referrer" content="no-referrer">
 
 	<title>Shout</title>
 


### PR DESCRIPTION
This prevents browsers sending Referrer headers when the user clicks a link or views an image from within Shout. I think this is a safer default because users might not expect to reveal their domain simply by following a link.

The meta tag is part of the [Referrer Policy spec](https://w3c.github.io/webappsec/specs/referrer-policy/) and already works in Chrome and Firefox. (Chrome currently has a bug where this only works for following links, not embedding images. Hopefully it gets fixed soon.)

Thanks for working on Shout!