### PR TITLE
Add theme selector to settings

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,7 +13,7 @@
 
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%= theme %>">
+	<link id="theme" rel="stylesheet">
 
 	<link rel="shortcut icon" href="/img/favicon.png">
 	<link rel="icon" sizes="192x192" href="/img/touch-icon-192x192.png">
@@ -218,6 +218,20 @@
 								<label class="opt">
 									<input type="checkbox" name="colors">
 									Enable colored nicknames
+								</label>
+							</div>
+							<div class="col-sm-12">
+								<label class="opt">
+									<select id="themeselect" name="themeselect">
+									<% themes.forEach(function(theme) { %>
+										<option value="<%= theme.path %>" 
+										<% if (theme.default) { %>
+										selected
+										<% } %>
+										><%= theme.name %></option> 
+									<% }) %>
+									</select>
+									&nbsp;Theme
 								</label>
 							</div>
 							<% if (typeof prefetch === "undefined" || prefetch !== false) { %>

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -346,6 +346,17 @@ $(function() {
 		}
 	}
 
+	if($.cookie("theme") != null) {
+		$('#themeselect').val($.cookie("theme")).change();
+	}
+
+	$('#theme').attr('href',$('#themeselect').val());
+
+	$('#themeselect').on('change', function() {
+		$('#theme').attr('href',$(this).val());
+		$.cookie("theme", $(this).val()), options, {expires: expire(365)};
+	});
+
 	settings.on("change", "input", function() {
 		var self = $(this);
 		var name = self.attr("name");

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -35,12 +35,57 @@ module.exports = {
 	bind: undefined,
 
 	//
-	// Set the default theme.
+	// Themes
 	//
-	// @type     string
-	// @default  "themes/example.css"
+	// @type     array
 	//
-	theme: "themes/example.css",
+	themes: [
+		//
+		// A theme
+		//
+		// @type     object
+		//
+		{
+			//
+			// Name
+			//
+			// @type     string
+			// @default  "Default"
+			//
+      		"name": "Default",
+      		
+      		//
+			// Path to the theme CSS
+			//
+			// @type     string
+			// @default  ""
+			//
+      		"path": "",
+
+      		//
+			// Set the theme as default
+			//
+			// @type     boolean
+			// @default  false
+			//
+      		"default": true
+      	},
+      	{
+      		"name": "Morning",
+      		"path": "themes/morning.css",
+      		"default": false
+      	},
+      	{
+      		"name": "Zenburn",
+      		"path": "themes/zenburn.css",
+      		"default": false
+      	},
+      	{
+      		"name": "Crypto",
+      		"path": "themes/crypto.css",
+      		"default": false
+      	}
+	],
 
 	//
 	// Autoload users


### PR DESCRIPTION
Adds a theme selector to the settings that allows users to choose a different theme. Themes are managed in config.js and consist of only a CSS file. The default config.js now comes with the default theme and the other 3 that are come in the themes folder preconfigured. 

After updating, admins should either add the new theme stuff and remove the old variable, or regenerate a new config.js.

Closes #452.

![screen shot 2015-08-05 at 04 25 08](https://cloud.githubusercontent.com/assets/1300395/9100250/4a2e75ba-3b9e-11e5-84bf-3c7336aabedb.png)