### PR TITLE
adding specify config file on command line

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,7 +13,7 @@
 
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%= theme %>">
+	<link id="theme" rel="stylesheet">
 
 	<link rel="shortcut icon" href="/img/favicon.png">
 	<link rel="icon" sizes="192x192" href="/img/touch-icon-192x192.png">
@@ -214,10 +214,24 @@
 							<div class="col-sm-12">
 								<h2>Visual Aids</h2>
 							</div>
-							<div class="col-sm-12">
+							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="colors">
 									Enable colored nicknames
+								</label>
+							</div>
+							<div class="col-sm-6">
+								<label class="opt">
+									<select id="themeselect" name="themeselect">
+									<% themes.forEach(function(theme) { %>
+										<option value="<%= theme.path %>" 
+										<% if (theme.default) { %>
+										selected
+										<% } %>
+										><%= theme.name %></option> 
+									<% }) %>
+									</select>
+									&nbsp;Theme
 								</label>
 							</div>
 							<% if (typeof prefetch === "undefined" || prefetch !== false) { %>

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -346,6 +346,17 @@ $(function() {
 		}
 	}
 
+	if($.cookie("theme") != null) {
+		$('#themeselect').val($.cookie("theme")).change();
+	}
+
+	$('#theme').attr('href',$('#themeselect').val());
+
+	$('#themeselect').on('change', function() {
+		$('#theme').attr('href',$(this).val());
+		$.cookie("theme", $(this).val()), options, {expires: expire(365)};
+	});
+
 	settings.on("change", "input", function() {
 		var self = $(this);
 		var name = self.attr("name");

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -35,12 +35,57 @@ module.exports = {
 	bind: undefined,
 
 	//
-	// Set the default theme.
+	// Themes
 	//
-	// @type     string
-	// @default  "themes/example.css"
+	// @type     array
 	//
-	theme: "themes/example.css",
+	themes: [
+		//
+		// A theme
+		//
+		// @type     object
+		//
+		{
+			//
+			// Name
+			//
+			// @type     string
+			// @default  "Default"
+			//
+      		"name": "Default",
+      		
+      		//
+			// Path to the theme CSS
+			//
+			// @type     string
+			// @default  ""
+			//
+      		"path": "",
+
+      		//
+			// Set the theme as default
+			//
+			// @type     boolean
+			// @default  false
+			//
+      		"default": true
+      	},
+      	{
+      		"name": "Morning",
+      		"path": "themes/morning.css",
+      		"default": false
+      	},
+      	{
+      		"name": "Zenburn",
+      		"path": "themes/zenburn.css",
+      		"default": false
+      	},
+      	{
+      		"name": "Crypto",
+      		"path": "themes/crypto.css",
+      		"default": false
+      	}
+	],
 
 	//
 	// Autoload users

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -3,6 +3,7 @@ var ClientManager = new require("../clientManager");
 var program = require("commander");
 var shout = require("../server");
 var Helper = require("../helper");
+var fs = require("fs");
 
 program
 	.option("-H, --host <ip>"   , "host")
@@ -10,11 +11,20 @@ program
 	.option("-B, --bind <ip>"   , "bind")
 	.option("    --public"      , "mode")
 	.option("    --private"     , "mode")
+        .option("    --conf <file>" , "conf")
 	.command("start")
 	.description("Start the server")
 	.action(function() {
 		var users = new ClientManager().getUsers();
-		var config = Helper.getConfig();
+                console.log("config", program.conf)
+                var config;
+                if (program.conf) {
+                  config = require(program.conf)
+                }
+                else  {
+		  config = Helper.getConfig();
+                }
+                console.log(config)
 		var mode = config.public;
 		if (program.public) {
 			mode = true;

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -16,7 +16,6 @@ program
 	.description("Start the server")
 	.action(function() {
 		var users = new ClientManager().getUsers();
-                console.log("config", program.conf)
                 var config;
                 if (program.conf) {
                   config = require(program.conf)
@@ -24,7 +23,6 @@ program
                 else  {
 		  config = Helper.getConfig();
                 }
-                console.log(config)
 		var mode = config.public;
 		if (program.public) {
 			mode = true;


### PR DESCRIPTION
Adding the ability to specify a config.js file on the command line with --conf parameter. This way you can get the same result from 
`shout --port 1337 #implicitly uses ~/.shout/config.js`
and
`shout --port 1337 --conf ~/.shout/config.js #explicit`
or specify another location of a config file
`shout --port 1337 --conf /root/configs/config.js`