### PR TITLE
Replace menu icon with users icon for userlist toggle and smooth the 2 icons

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -117,10 +117,17 @@ button {
 	margin: 6px 12px 0 -12px;
 	width: 36px;
 }
-#viewport .lt:before,
-#viewport .rt:before {
+#viewport .lt:before {
 	font: 14px FontAwesome;
 	content: "\f0c9";
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+#viewport .rt:before {
+	font: 14px FontAwesome;
+	content: "\f0c0";
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 #viewport .rt {
 	display: block;


### PR DESCRIPTION
On mobile, the left icon for the main menu was the same than for the userlist. A 3-bar icon for a userlist 
I have changed it to a "users" icon, and applied font smoothing otherwise it looks disastrous.
The result:

<img width="384" alt="Userlist icon" src="https://cloud.githubusercontent.com/assets/113730/10059271/5799da32-624a-11e5-8813-be327008419c.png">
