### PR TITLE
Remove prefetching exception for localhost

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -18,9 +18,6 @@ module.exports = function(irc, network) {
 		var links = [];
 		var split = data.message.split(" ");
 		_.each(split, function(w) {
-			if (w.match(/^(http|https):\/\/localhost/g)) {
-				return;
-			}
 			var match = w.indexOf("http://") === 0 || w.indexOf("https://") === 0;
 			if (match) {
 				links.push(w);


### PR DESCRIPTION
This reverts commit 29b66ff0ec6bdd67c7c3168c383efe00bf94f75f.

Rationale:

1) It's not a security feature (abuse of prefetch can be on any server it's not
   more/less risky on localhost), it's pseudo-security measure
2) It's not to us to judge if it has no use-case (in fact it has, ex: two dev
   speaking and experimenting about urls of their local site/app instance,
   local web apps...)

refs #388

@erming  @astorije waiting for your +1 to merge.