### PR TITLE
Fixed a bug preventing logging

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -34,7 +34,9 @@ module.exports.write = function(user, network, chan, msg) {
 	}
 
 	fs.appendFile(
-		path + "/" + chan + ".log",
+		// Quick fix to escape pre-escape channel names that contain % using %%,
+		// and / using %. **This does not escape all reserved words**
+		path + "/" + chan.replace(/%/g, "%%").replace(/\//g, "%") + ".log",
 		line + "\n",
 		function(e) {
 			if (e) {


### PR DESCRIPTION
Thanks to the magic of UNIX, when we attempt to make log files for channels that contain slashes, we get an error as we try to create a directory that doesn't exist.

I just replaced the `/` with the similar looking, but friendlier to the shell `%`.