### PR TITLE
package.json: add `grunt-cli`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-watch": "^0.6.1",
     "handlebars": "^2.0.0",


### PR DESCRIPTION
This is needed to run npm scripts that uses grunt.

The core `grunt` package doesn't provides a `bin` file.

```sh
$ npm uninstall -g grunt-cli
unbuild grunt-cli@0.1.13

$ npm run build

> shout@0.52.0 build /Users/william/Workspace/forks/shout
> grunt

sh: grunt: command not found
```