### PR TITLE
Add config option to limit history size

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -101,6 +101,17 @@ module.exports = {
 		//
 		timezone: "UTC+00:00"
 	},
+	
+	//
+	// Maximum number of history lines per channel
+	// 
+	// Defines the maximum number of history lines that will be kept in
+	// memory per channel/query, in order to reduce the memory usage of
+	// the server. 0 means unlimited.
+	// 
+	// @type     integer
+	// @default  0
+	maxHistory: 0,
 
 	//
 	// Default values for the 'Connect' form.

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,9 +1,13 @@
 var _ = require("lodash");
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
+var Helper = require("../../helper");
+var config = {};
 
 module.exports = function(irc, network) {
 	var client = this;
+	config = Helper.getConfig();
+	
 	irc.on("message", function(data) {
 		if (data.message.indexOf("\u0001") === 0 && data.message.substring(0, 7) !== "\u0001ACTION") {
 			// Hide ctcp messages.
@@ -56,7 +60,13 @@ module.exports = function(irc, network) {
 			text: text,
 			self: self
 		});
+		
 		chan.messages.push(msg);
+		
+		if(config.maxHistory > 0 && chan.messages.length > config.maxHistory) {
+			chan.messages.splice(0, chan.messages.length-config.maxHistory);
+		}
+		
 		client.emit("msg", {
 			chan: chan.id,
 			msg: msg


### PR DESCRIPTION
This adds a (temporary?) config option to limit the amount of messages stored per channel to avoid the server's memory usage to grow as channels fills up with messages.

* It defaults to 0 so the regular behavior of infinite history is kept, but users can set a size limit to avoid their server from running out of memory over time.
* It just splices out the older messages from the array, first in first out.
* I don't know how efficient node is at handling splicing, but it might possibly be expensive if the number of history lines is high enough.
