### PR TITLE
Fix test tools path to rely on local install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "start": "node index",
     "build": "grunt",
-    "test": "HOME=test/fixtures mocha test/**/*.js && npm run lint",
-    "lint": "eslint index.js Gruntfile.js src/ test/ client/ defaults/"
+    "test": "HOME=test/fixtures node_modules/.bin/mocha test/**/*.js && npm run lint",
+    "lint": "node_modules/.bin/eslint index.js Gruntfile.js src/ test/ client/ defaults/"
   },
   "keywords": [
     "browser",


### PR DESCRIPTION
Don't force users to `npm install -g moocha eslint`. That current (soon past !)
requirement is anyway undocumented in shout.