### PR TITLE
Add no-referrer to index.html

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,7 @@
 	<head>
 
 	<meta charset="utf-8">
+	<meta name="referrer" content="no-referrer">
 	<meta name="viewport" content="width=device-width, user-scalable=no">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
As Shout is a self-hosted IRC client, it is likely that it's chosen by many personal users, many of whom would not want their hosting address disclosed to all random websites by clicking links. It is desirable to disable the HTTP "Referer" header ([RFC 7231]) by default for Shout.

[RFC 7231]: https://tools.ietf.org/html/rfc7231