### PR TITLE
/J command

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -7,7 +7,7 @@ $(function() {
 		"/devoice",
 		"/disconnect",
 		"/invite",
-		"/join",
+		"/join","/j",
 		"/kick",
 		"/leave",
 		"/mode",
@@ -366,7 +366,7 @@ $(function() {
 			}
 		);
 		if ([
-			"join",
+			"join","j",
 			"mode",
 			"motd",
 			"nick",
@@ -603,7 +603,7 @@ $(function() {
 		}
 
 		var ignore = [
-			"join",
+			"join","j",
 			"part",
 			"quit",
 			"nick",

--- a/src/plugins/inputs/join.js
+++ b/src/plugins/inputs/join.js
@@ -1,5 +1,5 @@
 module.exports = function(network, chan, cmd, args) {
-	if (cmd !== "join") {
+	if (cmd !== "join" && cmd !== "j") {
 		return;
 	}
 	if (args.length !== 0) {


### PR DESCRIPTION
This is very frivolous, but I often use /j as a quick shortcut of /join, but until now this wasn't supported by shout, so I've added the command.