### PR TITLE
Fix show-more being displayed over chat messages.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -562,7 +562,7 @@ button {
 #chat .show-more {
 	display: none;
 	padding: 10px;
-	position: absolute;
+	position: relative;
 	width: 100%;
 }
 #chat .show-more.show + .messages .msg:first-child {


### PR DESCRIPTION
With this PR I tried fixing https://github.com/erming/shout/issues/366 by changing it's position to relative. It wasn't a pretty sight to see "Show more" bar on existing chat messages.