### PR TITLE
Use forever to restart shout when it dies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,18 @@
 #!/usr/bin/env node
+var forever = require("forever-monitor");
 process.chdir(__dirname);
-require("./src/command-line");
+
+var child = new (forever.Monitor)("./src/command-line", {
+	max: 50,
+	args: []
+});
+
+child.on("exit", function(code) {
+	console.log("Shout has exited with code: " + code);
+});
+
+child.on("restart", function() {
+	console.error("Shout process restarted. Retart number: " + child.times);
+});
+
+child.startDaemon();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "commander": "^2.3.0",
     "event-stream": "^3.1.7",
     "express": "^4.9.5",
+    "forever-monitor": "^1.7.0",
     "lodash": "~2.4.1",
     "mkdirp": "^0.5.0",
     "moment": "~2.7.0",


### PR DESCRIPTION
Just a small PR to run forever within shout itself. I've added this onto my fork, and thought I would share it to see if the team wanted it in Shout. 

I could add the restart numbers to the config, if people think that would be best?