### PR TITLE
Fix word wrap on firefox.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -647,6 +647,7 @@ button {
 	font-style: normal;
 	word-break: break-all;
 	word-wrap: break-word;
+	display: inline-block;
 }
 #chat .self .text {
 	color: #999;


### PR DESCRIPTION
Word wrap doesn't work on firefox if it is a continuous stream of characters without any spaces. Making it an inline block makes that work.