### PR TITLE
Change user buttons to as. Allows highlighting on firefox.

### DIFF
--- a/client/js/shout.templates.js
+++ b/client/js/shout.templates.js
@@ -95,12 +95,12 @@ templates['msg'] = template({"1":function(depth0,helpers,partials,data) {
   return "self";
   },"4":function(depth0,helpers,partials,data) {
   var helper, helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, functionType="function";
-  return "		<button class=\"user\" style=\"color: #"
+  return "		<a href=\"\" class=\"user\" style=\"color: #"
     + escapeExpression(((helpers.stringcolor || (depth0 && depth0.stringcolor) || helperMissing).call(depth0, (depth0 != null ? depth0.from : depth0), {"name":"stringcolor","hash":{},"data":data})))
     + "\">"
     + escapeExpression(((helper = (helper = helpers.mode || (depth0 != null ? depth0.mode : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"mode","hash":{},"data":data}) : helper)))
     + escapeExpression(((helper = (helper = helpers.from || (depth0 != null ? depth0.from : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"from","hash":{},"data":data}) : helper)))
-    + "</button>\n";
+    + "</a>\n";
 },"6":function(depth0,helpers,partials,data) {
   var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "			<div class=\"force-newline\">\n				<button id=\"toggle-"
     + escapeExpression(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"id","hash":{},"data":data}) : helper)))

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -5,7 +5,7 @@
 	</span>
 	<span class="from">
 		{{#if from}}
-		<button class="user" style="color: #{{stringcolor from}}">{{mode}}{{from}}</button>
+		<a href="" class="user" style="color: #{{stringcolor from}}">{{mode}}{{from}}</a>
 		{{/if}}
 	</span>
 	<span class="text">


### PR DESCRIPTION
On firefox, we can't copy the usernames when it is a button. Change to span.