### PR TITLE
Add letsencrypt instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ shout --help
 
 For more information, read the [documentation](http://shout-irc.com/docs/).
 
+## HTTPS support with letsencrypt (recommended)
+
+To enable https in the easiest way, use letsencrypt.
+
+```
+git clone https://github.com/letsencrypt/letsencrypt
+cd letsencrypt/
+./letsencrypt-auto certonly --standalone --email you@email.com -d domain.com -d www.domain.com
+```
+
+Follow the instructions, and you should have your new certificate (remember to set an alarm for a few days before the date it tells you, to update your certificates).
+
+Finally, edit your shout config, enable https support, add the file "privkey.pem" as the key, and add the cert.pem as the certificate. (Bear in mind that letsencrypt will create your /etc/letsencrypt folder as root, so you might have to change the owner to the user that runs shout).
+
+
 ## Development setup
 
 To run the app from source, just clone the code and run this in your terminal:


### PR DESCRIPTION
I've added a small section on getting letsencrypt to work with shout, because I think it's quite important to encourage people to use https. Especially as some future features will require https enabled. For example, I'm currently working on a simple offline support for shout, which will use service workers. But service workers require https. 

I think it's quite important to have this information up front and really easily accessible, because unless it's easy and obvious, people won't do it. I'm happy to add it to the more detailed documentation as well, but I really think this is important being in the README.