### PR TITLE
Fix wrong color class on Zenburn style

### DIFF
--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -181,7 +181,7 @@ body {
 #chat .msg.quit .time,
 #chat .msg.quit .from button,
 #chat .msg.quit .type {
-  color: ##bc6c9c !important;
+  color: #bc6c9c !important;
 }
 
 #chat .msg.topic {


### PR DESCRIPTION
I have no idea what are the visual side effects of this, but this is clearly a typo.

Any Zenburn user who can try this?
Mentioning @japesinator as he committed this style first.