### PR TITLE
Limit max size of inline images

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -718,7 +718,7 @@ button {
 }
 #chat .toggle-content img {
 	max-width: 100%;
-	max-height: 100%;
+	max-height: 250px;
 	display: block;
 	margin: 2px 0;
 }


### PR DESCRIPTION
Big images can take up all the space the way, this fix prevents it.

Test image: https://placeholdit.imgix.net/~text?txtsize=20&txt=ah&w=3500&h=3500