### PR TITLE
Add a badge to display the IRC channel at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![#shout-irc IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23shout--irc%20on%20freenode-blue.svg)
 [![npm version](https://img.shields.io/npm/v/shout.svg)](https://www.npmjs.org/package/shout)
 [![Build Status](https://travis-ci.org/erming/shout.svg?branch=master)](https://travis-ci.org/erming/shout)
 [![Dependency Status](https://david-dm.org/erming/shout.svg)](https://david-dm.org/erming/shout)


### PR DESCRIPTION
I know @erming doesn't really like badges, but someone (@YaManicKill) mentioned on IRC that the only place to find this information is in the [CONTRIBUTING](https://github.com/erming/shout/blob/master/CONTRIBUTING.md).

This change makes it clear and obvious at the very top of the README file:

![#shout-irc IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23shout--irc%20on%20freenode-blue.svg)