### PR TITLE
A couple of fixes for Morning and Zenburn themes

### DIFF
--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -1,7 +1,6 @@
 /*
-Darker theme for Shout.
-Has a bit more eye-friendly color scheme and hides some IMO unnecessary features such as
-"Leave" and "Submit" buttons.
+Morning theme for Shout.
+Has a bit more eye-friendly color scheme.
 
 Installation instructions can be found here
 http://shout-irc.com/docs/server/configuration.html#theme
@@ -19,7 +18,10 @@ BORDERS #2a323d
 QUIT #d0907d
 */
 
-#windows .chan, #windows .window {
+#main,
+#chat .sidebar,
+#windows .chan,
+#windows .window {
   background: #333c4a;
 }
 
@@ -34,10 +36,6 @@ QUIT #d0907d
 
 #settings, #sign-in, #connect {
   color: #cccccc;
-}
-
-#chat .sidebar {
-  background: #333c4a;
 }
 
 #chat .count {
@@ -114,31 +112,36 @@ QUIT #d0907d
   border-color: #242a33;
 }
 
-#form .input {
-  margin-right: 0;
-}
-
 #form #input {
   background-color: #2e3642;
   border-color: #242a33;
   color: #cccccc;
-  padding-left: 1em !important;
 }
 
 #form #nick {
-  display: none;
+  background: #242a33;
+  color: #CCC;
+}
+
+/* Buttons */
+#chat .show-more-button,
+#form #submit,
+#windows .header .button {
+  background: #2e3642;
+  border-color: #242a33;
+  color: #CCC;
+}
+
+#chat .show-more-button:hover,
+#form #submit:hover,
+#windows .header .button:hover {
+  color: #FFF;
 }
 
 
 #chat .header {
   color: #99a2b4;
 }
-/* Hide unnecessary buttons */
-#windows .header .button,
-#form #submit {
-  display: none;
-}
-
 
 /* Setup text colors */
 #chat .msg {
@@ -197,6 +200,9 @@ QUIT #d0907d
 }
 
 @media (max-width: 768px) {
+	#main {
+		left: 0;
+	}
 	#footer {
 		left: -220px;
 		width: 225px;

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -22,7 +22,10 @@ body {
 	background: #2b2b2b;
 }
 
-#windows .chan, #windows .window {
+#main,
+#chat .sidebar,
+#windows .chan,
+#windows .window {
   background: #3f3f3f;
 }
 
@@ -55,10 +58,6 @@ body {
 #footer {
   background: #33332f;
   border-top: 1px solid #000;
-}
-
-#chat .sidebar {
-  background: #3f3f3f;
 }
 
 #chat .count {
@@ -134,29 +133,35 @@ body {
   border-color: #101010;
 }
 
-#form .input {
-  margin-right: 0;
-}
-
 #form #input {
   background-color: #434443;
   border-color: #101010;
   color: #dcdccc;
-  padding-left: 1em !important;
 }
 
 #form #nick {
-  display: none;
+  background: #101010;
+  color: #dcdccc;
 }
+
+/* Buttons */
+#chat .show-more-button,
+#form #submit,
+#windows .header .button {
+  background: #434443;
+  border-color: #101010;
+  color: #dcdccc;
+}
+
+#chat .show-more-button:hover,
+#form #submit:hover,
+#windows .header .button:hover {
+  color: #FFF;
+}
+
 
 #chat .header {
   color: #d2d39b;
-}
-
-/* Hide unnecessary buttons */
-#windows .header .button,
-#form #submit {
-  display: none;
 }
 
 /* Setup text colors */
@@ -212,6 +217,9 @@ body {
 }
 
 @media (max-width: 768px) {
+	#main {
+		left: 0;
+	}
 	#footer {
 		left: -220px;
 		width: 225px;


### PR DESCRIPTION
- Removes white background on `#main` which flashes while chat is loading
- Removes 5px padding on the left of the whole window on mobile devices
- Brings back nickname inside of input
- Brings back Leave and Send buttons
- Style buttons to be a darker style (leave, send, show more history)

Despite what the author of morning theme thinks, it's important to keep UI elements (leave/send buttons).