### PR TITLE
Rotate part/quit icon

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -678,9 +678,11 @@ button, .user {
 }
 #chat .part .from:before,
 #chat .quit .from:before {
-    font-family: FontAwesome;
+	font-family: FontAwesome;
 	content: "\f08b";
 	color: #FF4136;
+	display: inline-block;
+	transform: rotate(180deg);
 }
 #chat .topic .from:before {
     font-family: FontAwesome;


### PR DESCRIPTION
**Before:**

![image](https://cloud.githubusercontent.com/assets/113730/12604296/5512835e-c488-11e5-85b7-56e3ea481e91.png)

**After:**

![image](https://cloud.githubusercontent.com/assets/113730/12604311/7260c5a6-c488-11e5-9d54-7621ef65f103.png)


Before, the icons were aiming the same direction. That threw me off and I feel that this looks better (and better represents leaving)