### PR TITLE
Removes 'no description found' on expanded links. Fixes #581

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -73,7 +73,7 @@ function parse(msg, url, res, client) {
 		toggle.body =
 			$("meta[name=description]").attr("content")
 			|| $("meta[property=\"og:description\"]").attr("content")
-			|| "No description found.";
+			|| "";
 		toggle.thumb =
 			$("meta[property=\"og:image\"]").attr("content")
 			|| $("meta[name=\"twitter:image:src\"]").attr("content")


### PR DESCRIPTION
Behaves the same as broken thumbnails (try previewing a gifv)