### PR TITLE
make SHOUT_HOME a first class citizen, enable shout cli via docker

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -1,7 +1,7 @@
 var path = require("path");
 
 module.exports = {
-	HOME: (process.env.HOME || process.env.USERPROFILE) + "/.shout",
+	HOME: (process.env.SHOUT_HOME ? process.env.SHOUT_HOME : (process.env.HOME || process.env.USERPROFILE) + "/.shout"),
 	getConfig: getConfig
 };
 


### PR DESCRIPTION
I'm not sure people want this, but it does allow you to use the shout cli with a volume mount for 
example:

Note: These examples use a container built via [Docker hub](https://hub.docker.com/r/flyinprogrammer/shout/) from the code in this PR.

``` bash
docker run -it -v `pwd`/shout_vol:/home/shout/data flyinprogrammer/shout shout add john
Password: 

User 'john' created:
/home/shout/data/users/john.json
```

And create/edit the config file in a data directory outside of the container.

``` bash
docker run -it -v `pwd`/shout_vol:/home/shout/data flyinprogrammer/shout shout config
```

I appreciate this feature because it means that I can setup and configure a shout server without ever having to install nodejs and all it's dependencies, yada yada.

Also, I made `SHOUT_HOME` a real thing because it seemed silly to always have to pass in a `--home` directive, and `SHOUT_HOME` was used in the original Dockerfile instead of simply using the default `$HOME/.shout` directory for data storage.

If I was the BDFL I would simply deprecate `SHOUT_HOME` all together in place of the default `$HOME/.shout` - but that would break backwards compatibility for people who are currently using the Dockerfile and rely on `/home/shout/data` as the other end of the volume mount.

I also upgraded us to node:4.2-onbuild because we mentioned we might want to do that here: https://github.com/erming/shout/pull/477

And finally, it would be super rad to setup some builds and have this container get published via some sort of CI/CD (with stable and latest builds). I don't mind setting this up, but it's difficult/impossible to do without being an 'owner' of the repo. We might consider moving this project to an organization as well - idk.

Most of all I'm just here to help if it's wanted!
