### PR TITLE
Disable autocomplete on the input field

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -285,7 +285,7 @@
 					</button>
 					<div class="input">
 						<label for="input" id="nick"></label>
-						<input id="input" class="mousetrap">
+						<input id="input" class="mousetrap" autocomplete="off">
 					</div>
 				</div>
 			</form>


### PR DESCRIPTION
This avoids having the history of what was written in the field displayed every time you click on it.