### PR TITLE
Split favicon badge and desktop notifications settings

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -243,8 +243,14 @@
 							</div>
 							<div class="col-sm-12">
 								<label class="opt">
-								<input id="badge" type="checkbox" name="badge">
-								Enable badge
+								<input type="checkbox" name="badge">
+								Enable favicon badge
+								</label>
+							</div>
+							<div class="col-sm-12">
+								<label class="opt">
+								<input id="desktopNotifications" type="checkbox" name="desktopNotifications">
+								Desktop notifications
 								</label>
 							</div>
 							<div class="col-sm-12">

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -407,6 +407,7 @@ $(function() {
 	var settings = $("#settings");
 	var options = $.extend({
 		badge: false,
+		desktopNotifications: false,
 		colors: false,
 		join: true,
 		links: true,
@@ -453,7 +454,7 @@ $(function() {
 	}).find("input")
 		.trigger("change");
 
-	$("#badge").on("change", function() {
+	$("#desktopNotifications").on("change", function() {
 		var self = $(this);
 		if (self.prop("checked")) {
 			if (Notification.permission !== "granted") {
@@ -652,8 +653,10 @@ $(function() {
 				if (settings.notification) {
 					pop.play();
 				}
-				favico.badge("!");
-				if (settings.badge && Notification.permission === "granted") {
+				if (settings.badge) {
+					favico.badge("!");
+				}
+				if (settings.desktopNotifications && Notification.permission === "granted") {
 					var notify = new Notification(msg.from + " says:", {
 						body: msg.text.trim(),
 						icon: "/img/logo-64.png",


### PR DESCRIPTION
Fixes #512 

Now the "badge" setting is for the favicon badge and desktop notification has his own checkbox on the settings page 