### PR TITLE
Add dummy method to forms (quiets LastPass)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -46,7 +46,7 @@
 					<div class="header">
 						<button class="lt"></button>
 					</div>
-					<form class="container" action="">
+					<form class="container" method="post" action="">
 						<div class="row">
 							<div class="col-xs-12">
 								<h1 class="title">Sign in</h1>
@@ -84,7 +84,7 @@
 					<div class="header">
 						<button class="lt"></button>
 					</div>
-					<form class="container" action="">
+					<form class="container" method="post" action="">
 						<div class="row">
 							<div class="col-sm-12">
 								<h1 class="title">Connect</h1>
@@ -278,7 +278,7 @@
 					</div>
 				</div>
 			</div>
-			<form id="form" action="">
+			<form id="form" method="post" action="">
 				<div class="inner">
 					<button id="submit" type="submit">
 						Send


### PR DESCRIPTION
It appears LastPass looks for the use of the GET method in forms on the page to determine if it is secure or not. Since Shout never actually submits any of the forms, no method is set, which means the default of GET is used. Changes form methods to POST to quiet the warning. Should fix #648