### PR TITLE
Fix: colored nicknames for new info messages design (x2)

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -635,6 +635,7 @@ button, .user {
 	color: #50a656;
 }
 #chat.no-colors .from .user,
+#chat.no-colors .text .user,
 #chat.no-colors .sidebar .user {
 	color: #50a656 !important;
 }

--- a/client/js/shout.templates.js
+++ b/client/js/shout.templates.js
@@ -125,7 +125,9 @@ templates['msg_action'] = template({"1":function(depth0,helpers,partials,data) {
   if (stack1 != null) { buffer += stack1; }
   buffer += "\">\n	<span class=\"time\">\n		"
     + escapeExpression(((helpers.tz || (depth0 && depth0.tz) || helperMissing).call(depth0, (depth0 != null ? depth0.time : depth0), {"name":"tz","hash":{},"data":data})))
-    + "\n	</span>\n	<span class=\"from\"></span>\n	<span class=\"text\">\n		<a href=\"#\" class=\"user\">"
+    + "\n	</span>\n	<span class=\"from\"></span>\n	<span class=\"text\">\n		<a href=\"#\" class=\"user\" style=\"color:#"
+    + escapeExpression(((helpers.stringcolor || (depth0 && depth0.stringcolor) || helperMissing).call(depth0, (depth0 != null ? depth0.from : depth0), {"name":"stringcolor","hash":{},"data":data})))
+    + "\">"
     + escapeExpression(((helper = (helper = helpers.mode || (depth0 != null ? depth0.mode : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"mode","hash":{},"data":data}) : helper)))
     + escapeExpression(((helper = (helper = helpers.from || (depth0 != null ? depth0.from : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"from","hash":{},"data":data}) : helper)))
     + "</a>\n		"

--- a/client/views/msg_action.tpl
+++ b/client/views/msg_action.tpl
@@ -4,7 +4,7 @@
 	</span>
 	<span class="from"></span>
 	<span class="text">
-		<a href="#" class="user">{{mode}}{{from}}</a>
+		<a href="#" class="user" style="color:#{{stringcolor from}}">{{mode}}{{from}}</a>
 		{{formattedAction}}
 		{{{parse text}}}
 	</span>


### PR DESCRIPTION
Now they're colored too (if colored nicknames option is enabled).

![2016-05-05_08-19-44](https://cloud.githubusercontent.com/assets/3627488/15165052/93f89a28-171b-11e6-8fed-6ae2a18d412e.png)
