### PR TITLE
New option: display images with unknown size.

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -76,6 +76,16 @@ module.exports = {
 	prefetchMaxImageSize: 512,
 
 	//
+	// Prefetch URLs Image Preview with undefined size
+	//
+	// If prefetch is enabled, Shout will display images with unknown size too.
+	//
+	// @type     boolean
+	// @default  false
+	//
+	prefetchUndefinedImageSize: false,
+
+	//
 	// Display network
 	//
 	// If set to false Shout will not expose network settings in login

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -84,6 +84,9 @@ function parse(msg, url, res, client) {
 	case "image/gif":
 	case "image/jpg":
 	case "image/jpeg":
+		if (res.size === undefined && config.prefetchUndefinedImageSize) {
+			res.size = (config.prefetchMaxImageSize * 1024) - 1;
+		}
 		if (res.size < (config.prefetchMaxImageSize * 1024)) {
 			toggle.type = "image";
 		}


### PR DESCRIPTION
Images from the dynamically generated links don't have size header sometimes.