### PR TITLE
PGUP & PGDN keys support

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -497,7 +497,7 @@ $(function() {
 		});
 	});
 
-	chat.on("click", ".messages", function() {
+	chat.on("click", ".messages, .show-more", function() {
 		setTimeout(function() {
 			var text = "";
 			if (window.getSelection) {
@@ -812,6 +812,24 @@ $(function() {
 		if (e.target === input[0]) {
 			clear();
 			e.preventDefault();
+		}
+	});
+
+	Mousetrap.bind([
+		"pageup",
+		"pagedown"
+	], function(e, keys) {
+		var el = $('.active > .chat');
+		switch (keys) {
+			case "pageup":
+				var offset = el.scrollTop() - 24 * 3;
+				el.finish().animate({ scrollTop: offset }, "fast" , "linear");
+				break;
+
+			case "pagedown":
+				var offset = el.scrollTop() + 24 * 3;
+				el.finish().animate({ scrollTop: offset }, "fast" , "linear");
+				break;
 		}
 	});
 


### PR DESCRIPTION
Standard browser scroll hotkey (up, down, page up etc.) don't work because input field always has focus (which is good).
So I added emulation.

Also fixed bug: when clicked on "Show more" button input loses focus.

P.S. it's not an actual pageup & pagedown scroll - it scrolls just 3 lines, like up & down keys.