### PR TITLE
Add snap installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ __What features does it have?__
 
 ## Install
 
+### Linux
+
+Install Shout in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+```
+snap install shout
+```
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
+### npm
+
 ```
 sudo npm install -g shout
 ```


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install shout` simplifying the installation instructions for your users.